### PR TITLE
Bump ansi-regex

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,11 @@ agent-base@6:
   dependencies:
     debug "4"
 
+ansi-regex@>=3.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"


### PR DESCRIPTION
## Overview

Bumps the version of ansi-regex, one of our transitive dependencies.

## Motivation

Dependabot security alerts:
- https://github.com/OpenIQL/inferenceql.inference/security/dependabot/1
- https://github.com/OpenIQL/inferenceql.inference/security/dependabot/2