### PR TITLE
Fix instructions for running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,16 @@
 
 ## Running the tests
 
-The test suite makes use of [`kaocha-cljs`](https://github.com/lambdaisland/kaocha-cljs#quickstart), which requires that the JavaScript package `ws` be installed.
+The Clojure tests can be run with:
 
 ```
-yarn install ws
+clojure -X:test:clj-test
 ```
 
-Once `ws` is installed the test suite can be run with [Kaocha](https://github.com/lambdaisland/kaocha):
+The ClojureScript tests can be run with:
 
 ```
-bin/kaocha
+clojure -X:test:cljs-test
 ```
 
 ### Generating test plots


### PR DESCRIPTION
## Overview

This pull request updates the instructions for running the tests in `CONTRIBUTING.md`.

## Motivation

The instructions in `CONTRIBUTING.md` for running the test suite still refer to Kaocha, which we no longer use as of a recent commit.