### PR TITLE
Implement logprob for conditioned GPMs

### DIFF
--- a/src/inferenceql/inference/gpm/conditioned.cljc
+++ b/src/inferenceql/inference/gpm/conditioned.cljc
@@ -7,14 +7,14 @@
     (let [merged-conditions (merge conditions logpdf-conditions)]
       (gpm.proto/logpdf gpm targets merged-conditions)))
 
+  (simulate [_ targets simulate-conditions]
+    (let [merged-conditions (merge conditions simulate-conditions)]
+      (gpm.proto/simulate gpm targets merged-conditions)))
+
   gpm.proto/LogProb
     (logprob [_ targets logprob-conditions]
       (let [merged-conditions (merge conditions logprob-conditions)]
        (gpm.proto/logprob gpm targets merged-conditions)))
-
-  (simulate [_ targets simulate-conditions]
-    (let [merged-conditions (merge conditions simulate-conditions)]
-      (gpm.proto/simulate gpm targets merged-conditions)))
 
   gpm.proto/Variables
   (variables [_]

--- a/src/inferenceql/inference/gpm/conditioned.cljc
+++ b/src/inferenceql/inference/gpm/conditioned.cljc
@@ -12,9 +12,12 @@
       (gpm.proto/simulate gpm targets merged-conditions)))
 
   gpm.proto/LogProb
-    (logprob [_ targets logprob-conditions]
-      (let [merged-conditions (merge conditions logprob-conditions)]
-       (gpm.proto/logprob gpm targets merged-conditions)))
+  (logprob [_ event]
+    (def conditions_event `(~'and ~@(map (fn [[variable value]]
+      `(~'= ~variable ~value))
+      conditions)))
+      (let [merged-event `(~'and ~conditions_event event)]
+       (gpm.proto/logprob gpm merged-event)))
 
   gpm.proto/Variables
   (variables [_]

--- a/src/inferenceql/inference/gpm/conditioned.cljc
+++ b/src/inferenceql/inference/gpm/conditioned.cljc
@@ -7,6 +7,11 @@
     (let [merged-conditions (merge conditions logpdf-conditions)]
       (gpm.proto/logpdf gpm targets merged-conditions)))
 
+  gpm.proto/LogProb
+    (logprob [_ targets logprob-conditions]
+      (let [merged-conditions (merge conditions logprob-conditions)]
+       (gpm.proto/logprob gpm targets merged-conditions)))
+
   (simulate [_ targets simulate-conditions]
     (let [merged-conditions (merge conditions simulate-conditions)]
       (gpm.proto/simulate gpm targets merged-conditions)))

--- a/src/inferenceql/inference/gpm/conditioned.cljc
+++ b/src/inferenceql/inference/gpm/conditioned.cljc
@@ -13,11 +13,15 @@
 
   gpm.proto/LogProb
   (logprob [_ event]
-    (def conditions_event `(~'and ~@(map (fn [[variable value]]
-      `(~'= ~variable ~value))
-      conditions)))
-      (let [merged-event `(~'and ~conditions_event event)]
-       (gpm.proto/logprob gpm merged-event)))
+      (let [
+        expression_list (map (fn [[variable value]] `(~'= ~variable ~value)) conditions)
+        conditions_event
+        (if (< 1 (count expression_list))
+          `(~'and ~@expression_list)
+          (first expression_list))
+        merged-event `(~'and ~conditions_event ~event)
+      ]
+      (gpm.proto/logprob gpm merged-event)))
 
   gpm.proto/Variables
   (variables [_]

--- a/src/inferenceql/inference/gpm/proto.cljc
+++ b/src/inferenceql/inference/gpm/proto.cljc
@@ -4,7 +4,6 @@
   "A simple protocol for defining a GPM."
   (logpdf             [this targets constraints])
   (simulate           [this targets constraints])
-  (logprob            [this targets constraints])
   (mutual-information [this target-a target-b constraints n-samples]))
 
 (defprotocol Incorporate

--- a/src/inferenceql/inference/gpm/proto.cljc
+++ b/src/inferenceql/inference/gpm/proto.cljc
@@ -3,6 +3,7 @@
 (defprotocol GPM
   "A simple protocol for defining a GPM."
   (logpdf             [this targets constraints])
+  (logprob            [this targets constraints])
   (simulate           [this targets constraints])
   (mutual-information [this target-a target-b constraints n-samples]))
 

--- a/src/inferenceql/inference/gpm/proto.cljc
+++ b/src/inferenceql/inference/gpm/proto.cljc
@@ -3,8 +3,8 @@
 (defprotocol GPM
   "A simple protocol for defining a GPM."
   (logpdf             [this targets constraints])
-  (logprob            [this targets constraints])
   (simulate           [this targets constraints])
+  (logprob            [this targets constraints])
   (mutual-information [this target-a target-b constraints n-samples]))
 
 (defprotocol Incorporate

--- a/test/inferenceql/inference/gpm/conditioned_test.cljc
+++ b/test/inferenceql/inference/gpm/conditioned_test.cljc
@@ -64,8 +64,7 @@
           (= expected (gpm/logprob conditioned-model event)))
 
   {:x 0} '(= :y 0) '(and (= :x 0) (= :y 0))
-  {:x 0 :y 0} '(= :z 1) '(and (and (= :x 0) (= :y 0)) (= :z 1))
-  ))
+  {:x 0 :y 0} '(= :z 1) '(and (and (= :x 0) (= :y 0)) (= :z 1))))
 
 (deftest simulate-conditions
   (are [c1 c2 expected]

--- a/test/inferenceql/inference/gpm/conditioned_test.cljc
+++ b/test/inferenceql/inference/gpm/conditioned_test.cljc
@@ -39,23 +39,6 @@
     [:x :y] {:y 1}
     [:x :y] {:x 0 :y 1}))
 
-(deftest logprob-targets
-  (are [targets conditions]
-      (let [model (reify gpm.proto/LogProb
-                    (logprob [_ actual _]
-                      actual))
-            conditioned-model (conditioned/condition model conditions)]
-        (= targets (gpm/logprob conditioned-model targets conditions)))
-    [] {}
-    [:x] {}
-    [] {:x 0}
-    [:x] {:x 0}
-    [:x :y] {}
-    [] {:x 0}
-    [:x :y] {:x 0}
-    [:x :y] {:y 1}
-    [:x :y] {:x 0 :y 1}))
-
 (deftest logpdf-conditions
   (are [condition-conditions conditions expected]
       (let [model (reify gpm.proto/GPM
@@ -63,22 +46,6 @@
                       actual))
             conditioned-model (conditioned/condition model condition-conditions)]
         (= expected (gpm/logpdf conditioned-model [:x] conditions)))
-    {} {} {}
-    {} {:x 0} {:x 0}
-    {:x 0} {} {:x 0}
-    {:x 0} {:x 1} {:x 1}
-    {:x 0} {:y 1} {:x 0 :y 1}
-    {:y 1} {:x 0} {:x 0 :y 1}
-    {:x 0 :z 2} {:y 1} {:x 0 :y 1 :z 2}
-    {:x 0} {:y 1 :z 2} {:x 0 :y 1 :z 2}))
-
-(deftest logprob-conditions
-  (are [condition-conditions conditions expected]
-      (let [model (reify gpm.proto/LogProb
-                    (logprob [_ _ actual]
-                      actual))
-            conditioned-model (conditioned/condition model condition-conditions)]
-        (= expected (gpm/logprob conditioned-model [:x] conditions)))
     {} {} {}
     {} {:x 0} {:x 0}
     {:x 0} {} {:x 0}
@@ -123,38 +90,6 @@
 (deftest logpdf-condition-twice
   (are [c1 c2 c3 expected]
       (let [model (-> (reify gpm.proto/GPM
-                        (simulate [_ _ actual]
-                          actual))
-                      (conditioned/condition c1)
-                      (conditioned/condition c2))]
-        (= expected (gpm/simulate model [:x] c3)))
-    {} {} {} {}
-    {:x 0} {} {} {:x 0}
-    {} {:x 0} {} {:x 0}
-    {} {} {:x 0} {:x 0}
-    {:x 0} {:x 1} {} {:x 1}
-    {:x 0} {} {:x 1} {:x 1}
-    {} {:x 0} {:x 1} {:x 1}))
-
-(deftest logprob-condition
-  (are [c1 c2 expected]
-      (let [model (-> (reify gpm.proto/LogProb
-                        (simulate [_ _ actual]
-                          actual))
-                      (conditioned/condition c1))]
-        (= expected (gpm/simulate model [:x] c2)))
-    {} {} {}
-    {} {:x 0} {:x 0}
-    {:x 0} {} {:x 0}
-    {:x 0} {:x 1} {:x 1}
-    {:x 0} {:y 1} {:x 0 :y 1}
-    {:y 1} {:x 0} {:x 0 :y 1}
-    {:x 0 :z 2} {:y 1} {:x 0 :y 1 :z 2}
-    {:x 0} {:y 1 :z 2} {:x 0 :y 1 :z 2}))
-
-(deftest logprob-condition-twice
-  (are [c1 c2 c3 expected]
-      (let [model (-> (reify gpm.proto/LogProb
                         (simulate [_ _ actual]
                           actual))
                       (conditioned/condition c1)

--- a/test/inferenceql/inference/gpm/conditioned_test.cljc
+++ b/test/inferenceql/inference/gpm/conditioned_test.cljc
@@ -55,6 +55,18 @@
     {:x 0 :z 2} {:y 1} {:x 0 :y 1 :z 2}
     {:x 0} {:y 1 :z 2} {:x 0 :y 1 :z 2}))
 
+(deftest logprob-conditions
+  (are [condition-conditions event expected]
+      (let [model (reify gpm.proto/LogProb
+                  (logprob [_ actual]
+                  actual))
+              conditioned-model (conditioned/condition model condition-conditions)]
+          (= expected (gpm/logprob conditioned-model event)))
+
+  {:x 0} '(= :y 0) '(and (= :x 0) (= :y 0))
+  {:x 0 :y 0} '(= :z 1) '(and (and (= :x 0) (= :y 0)) (= :z 1))
+  ))
+
 (deftest simulate-conditions
   (are [c1 c2 expected]
       (let [model (reify gpm.proto/GPM


### PR DESCRIPTION
This PR implements logprob for conditioned GPMs following conversations with @zane @Schaechtle. The tests are currently sparse: just a simple adaptation of the test for logpdf-conditions.

Happy to make changes based on feedback!