### PR TITLE
fix: Allow positive weights when calling simulate on ensemble models

### DIFF
--- a/src/inferenceql/inference/gpm/ensemble.cljc
+++ b/src/inferenceql/inference/gpm/ensemble.cljc
@@ -7,8 +7,6 @@
 
 (defn map->enumerated-distribution
   [m]
-  (when-not (every? (complement pos?) (vals m))
-    (throw (ex-info "Weights must be negative" {:weights (vals m)})))
   (let [pairs (ArrayList.)]
     (doseq [[k v] m]
       (.add pairs (Pair. k (math/exp (double v)))))


### PR DESCRIPTION
When calling gpm/simulate, a return of positive weights should be allowed

+ Remove two lines from map->enumerated-distribution that catch non-negative weights and throw an error
+ Apache's EnumeratedDistribution re-normalizes the weights so negative weights aren't required 