### PR TITLE
fix: Switch to dot constructor in defrecords

### DIFF
--- a/src/inferenceql/inference/gpm/conditioned.cljc
+++ b/src/inferenceql/inference/gpm/conditioned.cljc
@@ -18,7 +18,8 @@
   gpm.proto/Condition
   (condition [_ new-conditions]
     (let [merged-conditions (merge conditions new-conditions)]
-      (->ConditionedGPM gpm merged-conditions))))
+      ;; arrow ctor form was causing issues, so using dot form
+      (ConditionedGPM. gpm merged-conditions))))
 
 (defn condition
   "Conditions gpm based on conditions via rejection sampling. Arguments are the

--- a/test/inferenceql/inference/gpm/conditioned_test.cljc
+++ b/test/inferenceql/inference/gpm/conditioned_test.cljc
@@ -102,3 +102,17 @@
     {:x 0} {:x 1} {} {:x 1}
     {:x 0} {} {:x 1} {:x 1}
     {} {:x 0} {:x 1} {:x 1}))
+
+(deftest merged-conditions
+  (are [c1 c2 expected]
+    (let [model (conditioned/condition nil c1)
+          conditioned-model (gpm.proto/condition model c2)]
+      (= expected (:conditions conditioned-model)))
+    {} {} {}
+    {} {:x 0} {:x 0}
+    {:x 0} {} {:x 0}
+    {:x 0} {:x 1} {:x 1}
+    {:x 0} {:y 1} {:x 0 :y 1}
+    {:y 1} {:x 0} {:x 0 :y 1}
+    {:x 0 :z 2} {:y 1} {:x 0 :y 1 :z 2}
+    {:x 0} {:y 1 :z 2} {:x 0 :y 1 :z 2}))


### PR DESCRIPTION
Avoids cljs warning about ->ConditionedGPM being undefined